### PR TITLE
Load Infrared device driver

### DIFF
--- a/init.sun4i.rc
+++ b/init.sun4i.rc
@@ -56,6 +56,7 @@ on boot
         insmod /system/lib/modules/btusb.ko
         insmod /system/lib/modules/pl2303.ko
         insmod /system/lib/modules/tun.ko
+	insmod /system/lib/modules/sun4i-ir.ko #Infrared device
 
         #for stock roms
         insmod /system/vendor/modules/sun4i-vibrator.ko #Vibrator


### PR DESCRIPTION
For having infrared support, sun4i-ir.ko is needed.
